### PR TITLE
[#11] Only delete programs events in cron task

### DIFF
--- a/classes/local/calendar.php
+++ b/classes/local/calendar.php
@@ -181,6 +181,7 @@ final class calendar {
              LEFT JOIN {enrol_programs_allocations} pa ON pa.id = e.instance AND e.component = 'enrol_programs'
              LEFT JOIN {enrol_programs_programs} p ON p.id = pa.programid
                  WHERE (pa.id IS NULL OR pa.archived = 1 OR p.archived = 1 OR pa.timecompleted IS NOT NULL)
+                   AND e.component = 'enrol_programs'
                        $programselect
              ORDER BY e.id ASC";
         $rs = $DB->get_recordset_sql($sql, $params);


### PR DESCRIPTION
Closes #11 

- Added an extra condition to the SQL such that regardless of anything else, it will only ever match events that are from programs.
- Added a unit test that tests manual events are not touched by programs.